### PR TITLE
VV-2920 Create buffers based on the display size and color depth

### DIFF
--- a/PxMatrix.cpp
+++ b/PxMatrix.cpp
@@ -521,10 +521,12 @@ void PxMATRIX::setColorDepth(uint8_t color_depth) {
   for (uint8_t i = 0; i < _color_depth; i++) {
     if (PxMATRIX_buffer.Data[i] == nullptr) {
       PxMATRIX_buffer.Data[i] = new uint8_t[(_width * _height * 3) / 8];
+      memset(PxMATRIX_buffer.Data[i], 0, (_width * _height * 3) / 8);
     }
 #ifdef PxMATRIX_double_buffer
     if (PxMATRIX_buffer2.Data[i] == nullptr) {
       PxMATRIX_buffer2.Data[i] = new uint8_t[(_width * _height * 3) / 8];
+      memset(PxMATRIX_buffer2.Data[i], 0, (_width * _height * 3) / 8);
     }
 #endif
   }

--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -43,7 +43,6 @@ BSD license, check license.txt for more information
 #ifndef PxMATRIX_MAX_PIXELS
 #define PxMATRIX_MAX_PIXELS (PxMATRIX_MAX_HEIGHT * PxMATRIX_MAX_WIDTH)
 #endif
-#define buffer_size (PxMATRIX_MAX_PIXELS * 3 / 8)
 
 // Defines how long we display things by default
 #ifndef PxMATRIX_DEFAULT_SHOWTIME
@@ -85,6 +84,7 @@ BSD license, check license.txt for more information
 #endif
 
 #include <SPI.h>
+
 #include "Adafruit_GFX.h"
 #include "Arduino.h"
 
@@ -155,7 +155,7 @@ enum driver_chips { SHIFT, FM6124, FM6126A };
 enum color_orders { RRGGBB, RRBBGG, GGRRBB, GGBBRR, BBRRGG, BBGGRR };
 
 struct PxMatrixBuffer {
-  uint8_t Data[PxMATRIX_MAX_COLOR_DEPTH][buffer_size] = {0};
+  uint8_t* Data[PxMATRIX_MAX_COLOR_DEPTH] = {0};
 };
 
 class PxMATRIX : public Adafruit_GFX {


### PR DESCRIPTION
**Changes:**

- Allocate the buffers to store the display data when the color depth is set
- Allocate only the memory really needed

**Tested:**
- Functionally tested